### PR TITLE
fix shellscript_plugin template

### DIFF
--- a/plugins/distractions/shellscript/script_template.sh
+++ b/plugins/distractions/shellscript/script_template.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 if [ $1 = allow ]; then
     echo Do stuff to re-enable distractions
 else


### PR DESCRIPTION
Without such a header, the plugin does not work correctly in Arch Linux.